### PR TITLE
Removed print lines in utils.c

### DIFF
--- a/gerris-stable/src/utils.c
+++ b/gerris-stable/src/utils.c
@@ -1359,8 +1359,6 @@ GfsVariable * gfs_function_get_variable (GfsFunction * f)
 {
   g_return_val_if_fail (f != NULL, NULL);
 
-  if(f->v)
-    printf("GET VARIABLE: %s",(f->v)->name );
   return f->v;
 }
 


### PR DESCRIPTION
We found some annoying print messages when using simulations having Tracers and other variables, so we removed them.
